### PR TITLE
Enqueue scripts & styles in footer

### DIFF
--- a/includes/class-assets.php
+++ b/includes/class-assets.php
@@ -23,7 +23,7 @@ class Assets {
 	public static function init(): void {
 		// Only load assets on the frontend, not in admin.
 		if ( ! is_admin() ) {
-			add_action( 'wp_enqueue_scripts', [ __CLASS__, 'enqueue_assets' ] );
+			add_action( 'wp_footer', [ __CLASS__, 'enqueue_assets' ], 1 );
 		}
 	}
 


### PR DESCRIPTION
In https://github.com/ProgressPlanner/pp-glossary/pull/10 we added conditional enqueueing for CSS & JS files, so they are enqueued only on pages on which detect glossary terms (including Glossary page).

When I was working on it I tested it (including default WP 202x themes) and `the_content` filter was running before the `wp_enqueue_scripts` and terms were detected in time. But we got an [issue reported](https://github.com/ProgressPlanner/pp-glossary/issues/12) that the assets are missing, caused by the `the_content` filter being applied after the `wp_enqueue_scripts`.

This PR fixes that by delaying enqueue to the `wp_footer` hook, by which time all the (post) content on the page should already be processed.

Calling `wp_enqueue_script` & `wp_enqueue_style` this late will make WP core to enqueue scripts and styles in the footer instead in `<head>` like it was before.
